### PR TITLE
Add verbosity levels for evolution progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ number of randomly generated task instances. By default it uses
 ``AdditionTask`` which places two inputs on the tape and expects their sum in
 the first cell when the program halts. The returned score is the count of
 instances solved correctly.
+
+Verbosity
+---------
+Use the ``-v``/``--verbose`` flag to display progress during evolution.
+Passing ``-v`` prints the best and average score for each generation. Using
+``-vv`` additionally prints the current best program.

--- a/evolver.py
+++ b/evolver.py
@@ -51,7 +51,7 @@ def _select(population: Sequence[str], weights: Sequence[float], rng: random.Ran
 def evolve(population_size: int, elite_count: int, generations: int, *,
            mutation_rate: float = 0.1, crossover_rate: float = 0.5,
            task: Task | None = None, instances: int = 10,
-           rng: random.Random | None = None) -> tuple[str, int]:
+           rng: random.Random | None = None, verbose: int = 0) -> tuple[str, int]:
     """Evolve a BrainFuck program.
 
     Parameters
@@ -72,6 +72,9 @@ def evolve(population_size: int, elite_count: int, generations: int, *,
         Number of task instances used per evaluation.
     rng:
         Optional random generator.
+    verbose:
+        Verbosity level. ``0`` disables progress output. Higher values print
+        additional statistics during evolution.
 
     Returns
     -------
@@ -85,7 +88,7 @@ def evolve(population_size: int, elite_count: int, generations: int, *,
     best_prog = ""
     best_score = -1
 
-    for _ in range(generations):
+    for gen in range(generations):
         scores = [evaluate(prog, task=task, instances=instances, rng=rng)
                   for prog in population]
         pairs = list(zip(population, scores))
@@ -96,6 +99,13 @@ def evolve(population_size: int, elite_count: int, generations: int, *,
         if scores[0] > best_score:
             best_prog = population[0]
             best_score = scores[0]
+
+        if verbose:
+            avg = sum(scores) / len(scores)
+            msg = f"Gen {gen + 1}/{generations}: best={scores[0]} avg={avg:.2f}"
+            print(msg)
+            if verbose > 1:
+                print(f"  Best program: {population[0]!r}")
 
         elites = population[:elite_count]
         weights = scores

--- a/main.py
+++ b/main.py
@@ -27,6 +27,8 @@ def main() -> None:
                         help="maximum random input value for the addition task")
     parser.add_argument("--seed", type=int, default=None,
                         help="random seed")
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="increase verbosity; can be specified multiple times")
 
     args = parser.parse_args()
 
@@ -44,6 +46,7 @@ def main() -> None:
         task=task,
         instances=args.instances,
         rng=rng,
+        verbose=args.verbose,
     )
 
     print(program)


### PR DESCRIPTION
## Summary
- support `-v/--verbose` argument to control output detail
- show average and best scores each generation when verbose
- document verbosity levels

## Testing
- `python -m py_compile *.py`
- `python main.py --help | head -n 20`
- `python main.py --population-size 10 --generations 2 -v | head -n 20`
- `python main.py --population-size 5 --generations 1 -vv | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_683f464411f8832f93ad97a1f110f46d