### PR TITLE
Implement continuous fitness scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Fitness Evaluation
 The ``evaluate`` function in ``fitness.py`` executes a BrainFuck program on a
 number of randomly generated task instances. By default it uses
 ``AdditionTask`` which places two inputs on the tape and expects their sum in
-the first cell when the program halts. The returned score is the count of
-instances solved correctly.
+the first cell when the program halts. The returned score sums the negative
+absolute difference between the expected and produced value for each
+instance, so perfect solutions achieve the highest (least negative) score.
 
 Verbosity
 ---------

--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ def main() -> None:
     )
 
     print(program)
-    print(f"Score: {score}/{args.instances}")
+    print(f"Score: {score:.2f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- introduce a `fitness` method on tasks
- compute fitness as negative distance from the expected output
- shift negative scores to use them as selection weights
- update CLI output and documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f4a134494832fac89f39ed31e20ed