### PR TITLE
Add evaluation step limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ the first cell when the program halts. The returned score sums the negative
 absolute difference between the expected and produced value for each
 instance, so perfect solutions achieve the highest (least negative) score.
 
+The ``--steps`` command line option controls how many instructions a program
+may execute when being evaluated. It defaults to ``1000``.
+
 Verbosity
 ---------
 Use the ``-v``/``--verbose`` flag to display progress during evolution.

--- a/evolver.py
+++ b/evolver.py
@@ -61,7 +61,7 @@ def _select(population: Sequence[str], fitnesses: Sequence[float], rng: random.R
 
 def evolve(population_size: int, elite_count: int, generations: int, *,
            mutation_rate: float = 0.1, crossover_rate: float = 0.5,
-           task: Task | None = None, instances: int = 10,
+           task: Task | None = None, instances: int = 10, steps: int = 1000,
            rng: random.Random | None = None, verbose: int = 0) -> tuple[str, float]:
     """Evolve a BrainFuck program.
 
@@ -81,6 +81,8 @@ def evolve(population_size: int, elite_count: int, generations: int, *,
         Evaluation task used for fitness calculation.
     instances:
         Number of task instances used per evaluation.
+    steps:
+        Maximum instructions to execute per evaluation.
     rng:
         Optional random generator.
     verbose:
@@ -100,7 +102,8 @@ def evolve(population_size: int, elite_count: int, generations: int, *,
     best_score = float("-inf")
 
     for gen in range(generations):
-        scores = [evaluate(prog, task=task, instances=instances, rng=rng)
+        scores = [evaluate(prog, task=task, instances=instances,
+                          steps=steps, rng=rng)
                   for prog in population]
         pairs = list(zip(population, scores))
         pairs.sort(key=lambda p: p[1], reverse=True)
@@ -136,7 +139,8 @@ def evolve(population_size: int, elite_count: int, generations: int, *,
         population = new_population
 
     # Final evaluation to return accurate best score
-    final_scores = [evaluate(prog, task=task, instances=instances, rng=rng)
+    final_scores = [evaluate(prog, task=task, instances=instances,
+                            steps=steps, rng=rng)
                     for prog in population]
     best_idx = max(range(len(population)), key=lambda i: final_scores[i])
     return population[best_idx], final_scores[best_idx]

--- a/fitness.py
+++ b/fitness.py
@@ -42,7 +42,7 @@ class AdditionTask:
 
 
 def evaluate(program: str, *, task: Task | None = None, instances: int = 1,
-             steps: int = 100, rng: random.Random | None = None) -> float:
+             steps: int = 1000, rng: random.Random | None = None) -> float:
     """Evaluate ``program`` on ``instances`` of ``task``.
 
     Parameters

--- a/main.py
+++ b/main.py
@@ -27,6 +27,8 @@ def main() -> None:
                         help="maximum random input value for the addition task")
     parser.add_argument("--seed", type=int, default=None,
                         help="random seed")
+    parser.add_argument("--steps", type=int, default=1000,
+                        help="maximum instructions executed per evaluation")
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="increase verbosity; can be specified multiple times")
 
@@ -45,6 +47,7 @@ def main() -> None:
         crossover_rate=args.crossover_rate,
         task=task,
         instances=args.instances,
+        steps=args.steps,
         rng=rng,
         verbose=args.verbose,
     )


### PR DESCRIPTION
## Summary
- make evaluation run for 1000 steps by default
- allow specifying number of steps via `--steps`
- document steps option in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_683f4c5a6048832fb540d4837aaa7f8e