### PR TITLE
Ensure AdditionTask uses positive inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Fitness Evaluation
 The ``evaluate`` function in ``fitness.py`` executes a BrainFuck program on a
 number of randomly generated task instances. By default it uses
 ``AdditionTask`` which places two inputs on the tape and expects their sum in
-the first cell when the program halts. The returned score sums the negative
-absolute difference between the expected and produced value for each
-instance, so perfect solutions achieve the highest (least negative) score.
+the first cell when the program halts. The inputs are sampled from
+non-negative values only. The returned score sums the negative absolute
+difference between the expected and produced value for each instance, so
+perfect solutions achieve the highest (least negative) score.
 
 The ``--steps`` command line option controls how many instructions a program
 may execute when being evaluated. It defaults to ``1000``.

--- a/fitness.py
+++ b/fitness.py
@@ -30,8 +30,12 @@ class AdditionTask:
     max_value: int = 63
 
     def generate_input(self, rng: random.Random) -> List[int]:
-        a = rng.randint(self.min_value, self.max_value)
-        b = rng.randint(self.min_value, self.max_value)
+        """Return a tape where both inputs are positive."""
+
+        low = max(0, self.min_value)
+        high = max(low, self.max_value)
+        a = rng.randint(low, high)
+        b = rng.randint(low, high)
         tape = [a, b] + [0] * (self.size - 2)
         return tape
 


### PR DESCRIPTION
## Summary
- only sample positive values in `AdditionTask.generate_input`
- document that addition inputs are now non-negative

## Testing
- `python -m py_compile fitness.py executor.py evolver.py main.py`
- `python - <<'PY'
from fitness import AdditionTask
import random
rng = random.Random(0)
task = AdditionTask(min_value=-10, max_value=5)
for _ in range(5):
    t = task.generate_input(rng)
    print(t)
PY`

------
https://chatgpt.com/codex/tasks/task_e_683f62b4eed8832fa24ddae666b8b7e4