### PR TITLE
Remove unused BF instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-The goal of this project is to evolve programs in BrainFuck. The first thing we need to do is implement a simple executor that takes as input a string (representing a program in BrainFuck) and executes it. The language consists of 8 characters, which operate as follows:
+The goal of this project is to evolve programs in BrainFuck. The first thing we need to do is implement a simple executor that takes as input a string (representing a program in BrainFuck) and executes it. The language consists of 6 characters, which operate as follows:
 
 Character	Instruction Performed
 >	Increment the data pointer by one (to point to the next cell to the right).
 <	Decrement the data pointer by one (to point to the next cell to the left).
 +	Increment the byte at the data pointer by one.
 -	Decrement the byte at the data pointer by one.
-.	Output the byte at the data pointer.
-,	Accept one byte of input, storing its value in the byte at the data pointer.
 [	If the byte at the data pointer is zero, then instead of moving the instruction pointer forward to the next command, jump it forward to the command after the matching ] command.
 ]	If the byte at the data pointer is nonzero, then instead of moving the instruction pointer forward to the next command, jump it back to the command after the matching [ command.
 

--- a/evolver.py
+++ b/evolver.py
@@ -8,7 +8,7 @@ from typing import Sequence
 from fitness import Task, evaluate, AdditionTask
 
 
-INSTRUCTIONS = "><+-.,[]"
+INSTRUCTIONS = "><+-[]"
 
 
 def _mutate(program: str, rng: random.Random, rate: float) -> str:

--- a/executor.py
+++ b/executor.py
@@ -31,14 +31,13 @@ def _build_bracket_map(program: str) -> Mapping[int, int]:
     return pairs
 
 
-def execute(program: str, *, steps: int, size: int, initial: Iterable[int] | None = None,
-            input_data: Iterable[int] | None = None) -> List[int]:
+def execute(program: str, *, steps: int, size: int, initial: Iterable[int] | None = None) -> List[int]:
     """Execute ``program`` for up to ``steps`` instructions.
 
     Parameters
     ----------
     program:
-        BrainFuck program consisting of the characters ``><+-.,[]``. Any other
+        BrainFuck program consisting of the characters ``><+-[]``. Any other
         characters are ignored.
     steps:
         Maximum number of instructions to execute.
@@ -47,9 +46,6 @@ def execute(program: str, *, steps: int, size: int, initial: Iterable[int] | Non
     initial:
         Optional iterable of initial cell values. If fewer than ``size`` values
         are provided, remaining cells start at ``0``.
-    input_data:
-        Optional iterable of input values consumed by ```,` commands. Missing
-        input results in storing ``0``.
 
     Returns
     -------
@@ -70,7 +66,6 @@ def execute(program: str, *, steps: int, size: int, initial: Iterable[int] | Non
 
     data_ptr = 0
     instr_ptr = 0
-    input_iter = iter(input_data or [])
 
     executed = 0
     prog_len = len(program)
@@ -85,13 +80,6 @@ def execute(program: str, *, steps: int, size: int, initial: Iterable[int] | Non
             tape[data_ptr] = _wrap_byte(tape[data_ptr] + 1)
         elif command == '-':
             tape[data_ptr] = _wrap_byte(tape[data_ptr] - 1)
-        elif command == '.':
-            pass  # Output is ignored
-        elif command == ',':
-            try:
-                tape[data_ptr] = _wrap_byte(next(input_iter))
-            except StopIteration:
-                tape[data_ptr] = 0
         elif command == '[':
             if tape[data_ptr] == 0:
                 match = bracket_map.get(instr_ptr)


### PR DESCRIPTION
## Summary
- drop `.` and `,` BrainFuck instructions
- update README to mention only six instructions
- simplify executor and mutation constants accordingly

## Testing
- `python -m py_compile evolver.py executor.py fitness.py main.py`
- `python main.py --generations 1 --population-size 5 -v`

------
https://chatgpt.com/codex/tasks/task_e_68410e7fbb78832fbe8f8e76617d71c4