### PR TITLE
Add TripleAdditionTask for summing three numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ non-negative values only. The returned score sums the negative absolute
 difference between the expected and produced value for each instance, so
 perfect solutions achieve the highest (least negative) score.
 
+``TripleAdditionTask`` extends this idea by placing three inputs on the tape
+and expecting their sum in the first cell. The default bounds ensure that the
+sum never exceeds the signed byte range.
+
 The ``--steps`` command line option controls how many instructions a program
 may execute when being evaluated. It defaults to ``1000``.
 

--- a/fitness.py
+++ b/fitness.py
@@ -45,6 +45,33 @@ class AdditionTask:
         return -float(error)
 
 
+@dataclass
+class TripleAdditionTask:
+    """Task: sum the first three cells without overflow."""
+
+    size: int = 8
+    min_value: int = -42
+    max_value: int = 42
+
+    def generate_input(self, rng: random.Random) -> List[int]:
+        """Return a tape with three positive inputs.
+
+        The range is restricted so that the sum fits into a signed byte.
+        """
+        low = max(0, self.min_value)
+        high = max(low, self.max_value)
+        a = rng.randint(low, high)
+        b = rng.randint(low, high)
+        c = rng.randint(low, high)
+        tape = [a, b, c] + [0] * (self.size - 3)
+        return tape
+
+    def fitness(self, initial: List[int], final: List[int]) -> float:
+        expected = initial[0] + initial[1] + initial[2]
+        error = abs(final[0] - expected)
+        return -float(error)
+
+
 def evaluate(program: str, *, task: Task | None = None, instances: int = 1,
              steps: int = 1000, rng: random.Random | None = None,
              inputs: Sequence[List[int]] | None = None) -> float:

--- a/tests/test_fitness.py
+++ b/tests/test_fitness.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import random
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from fitness import TripleAdditionTask
+
+def test_triple_addition_bounds():
+    task = TripleAdditionTask()
+    rng = random.Random(0)
+    for _ in range(100):
+        tape = task.generate_input(rng)
+        a, b, c = tape[:3]
+        assert a >= 0 and b >= 0 and c >= 0
+        assert a + b + c <= 127
+
+def test_triple_addition_fitness():
+    task = TripleAdditionTask()
+    initial = [5, 6, 7] + [0] * (task.size - 3)
+    final = [18] + [0] * (task.size - 1)
+    assert task.fitness(initial, final) == 0
+    final_bad = [17] + [0] * (task.size - 1)
+    assert task.fitness(initial, final_bad) == -1.0


### PR DESCRIPTION
## Summary
- create `TripleAdditionTask` that sums three positive cells
- document new task in README
- test generation bounds and fitness

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684111129938832f9ddc5d355f09e4c1