### PR TITLE
Enhance initial diversity for evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ perfect solutions achieve the highest (least negative) score.
 and expecting their sum in the first cell. The default bounds ensure that the
 sum never exceeds the signed byte range.
 
+Initialization
+--------------
+The population can optionally start with random programs rather than empty
+strings. Use the ``--init-length`` option to specify how many instructions the
+initial programs contain. This helps the search discover useful building blocks
+more quickly.
+
 The ``--steps`` command line option controls how many instructions a program
 may execute when being evaluated. It defaults to ``1000``.
 

--- a/main.py
+++ b/main.py
@@ -19,6 +19,8 @@ def main() -> None:
                         help="probability of creating offspring via crossover")
     parser.add_argument("--instances", type=int, default=10,
                         help="number of evaluation instances per program")
+    parser.add_argument("--init-length", type=int, default=10,
+                        help="initial random program length")
     parser.add_argument("--task", choices=["addition", "triple"], default="addition",
                         help="evaluation task to use")
     parser.add_argument("--size", type=int, default=8,
@@ -56,6 +58,7 @@ def main() -> None:
         task=task,
         instances=args.instances,
         steps=args.steps,
+        init_length=args.init_length,
         rng=rng,
         verbose=args.verbose,
     )


### PR DESCRIPTION
## Summary
- add helper to create random programs and insert bracket pairs more often
- allow starting population with random programs via new `--init-length` option
- document how to use the new initialization feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684115464900832f8b2d30b3ed9eca8e